### PR TITLE
CheckObjectVisibility Fix

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -228,7 +228,7 @@ namespace Unity.Netcode
 
         internal void AddSpawnedNetworkObjects()
         {
-            m_NetworkObjectsSync = m_NetworkManager.SpawnManager.SpawnedObjectsList.ToList();
+            m_NetworkObjectsSync = m_NetworkManager.SpawnManager.SpawnedObjectsList.Where(x => x.Observers.Contains(TargetClientId)).ToList();
             m_NetworkObjectsSync.Sort(SortNetworkObjects);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -774,7 +774,7 @@ namespace Unity.Netcode
         {
             foreach (var sobj in SpawnedObjectsList)
             {
-                if (sobj.CheckObjectVisibility == null || NetworkManager.IsServer)
+                if (sobj.CheckObjectVisibility == null || NetworkManager.ServerClientId == clientId)
                 {
                     if (!sobj.Observers.Contains(clientId))
                     {


### PR DESCRIPTION
- Changes to fix CheckObjectVisibility delegate not being called for players joining after network objects have been spawned with the delegate set