### PR TITLE
Snapshot spawn system visibility fixes

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -438,12 +438,18 @@ namespace Unity.Netcode
 
         private void SnapshotSpawn()
         {
+#region OOI_CC
+            MarkVariablesDirty();
+#endregion
             var command = GetSpawnCommand();
             NetworkManager.SnapshotSystem.Spawn(command);
         }
 
         private void SnapshotSpawn(ulong clientId)
         {
+#region OOI_CC
+            MarkVariablesDirty();
+#endregion
             var command = GetSpawnCommand();
             command.TargetClientIds = new List<ulong>();
             command.TargetClientIds.Add(clientId);

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -194,7 +194,9 @@ namespace Unity.Netcode
             return pos;
         }
 
-        internal List<ulong> GetClientList()
+#region OOI_CC
+        internal List<ulong> GetClientList(NetworkObject networkObject)
+#endregion
         {
             List<ulong> clientList;
             clientList = new List<ulong>();
@@ -207,7 +209,9 @@ namespace Unity.Netcode
             {
                 foreach (var clientId in ConnectedClientsId)
                 {
-                    if (clientId != m_NetworkManager.ServerClientId)
+#region OOI_CC
+                    if (clientId != m_NetworkManager.ServerClientId && networkObject.Observers.Contains(clientId))
+#endregion
                     {
                         clientList.Add(clientId);
                     }
@@ -230,7 +234,9 @@ namespace Unity.Netcode
             {
                 if (command.TargetClientIds == default)
                 {
-                    command.TargetClientIds = GetClientList();
+#region OOI_CC
+                    command.TargetClientIds = GetClientList(command.NetworkObject);
+#endregion
                 }
 
                 // todo: store, for each client, the spawn not ack'ed yet,
@@ -270,7 +276,9 @@ namespace Unity.Netcode
             {
                 if (command.TargetClientIds == default)
                 {
-                    command.TargetClientIds = GetClientList();
+#region OOI_CC
+                    command.TargetClientIds = GetClientList(command.NetworkObject);
+#endregion
                 }
                 if (command.TargetClientIds.Count > 0)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -230,7 +230,9 @@ namespace Unity.Netcode
 
         internal void AddSpawnedNetworkObjects()
         {
+#region OOI_CC
             m_NetworkObjectsSync = m_NetworkManager.SpawnManager.SpawnedObjectsList.Where(x => x.Observers.Contains(TargetClientId)).ToList();
+#endregion
             m_NetworkObjectsSync.Sort(SortNetworkObjects);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -804,7 +804,9 @@ namespace Unity.Netcode
         {
             foreach (var sobj in SpawnedObjectsList)
             {
+#region OOI_CC
                 if (sobj.CheckObjectVisibility == null || NetworkManager.ServerClientId == clientId)
+#endregion
                 {
                     if (!sobj.Observers.Contains(clientId))
                     {


### PR DESCRIPTION
Fix network visibility issues introduced by snapshot spawn system: netvars will be marked as dirty when an object is shown to a player so that they will receive the correct values, and objects spawned with a CheckObjectVisibility delegate set will now use the results of the delegate to determine which players should actually see the object