### PR TITLE
added custom action listener for network messages stats

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -62,7 +62,20 @@ namespace Unity.Netcode
         }
 
         internal MessagingSystem MessagingSystem { get; private set; }
-
+        #region OOI_CC
+        public void SetMessageSentInternalListener(Action<string, int, int> action)
+        {
+            MessagingSystem.OnMessageSent += action;
+        }
+        public void RemoveMessageSentInternalListener(Action<string, int, int> action)
+        {
+            MessagingSystem.OnMessageSent -= action;
+        }
+        public void EnableMessageSentListener(bool flag)
+        {
+            MessagingSystem.ReportMessage = flag;
+        }
+        #endregion
         private NetworkPrefabHandler m_PrefabHandler;
 
         internal Dictionary<ulong, ConnectionApprovalResponse> ClientsToApprove = new Dictionary<ulong, ConnectionApprovalResponse>();

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -688,9 +688,20 @@ namespace Unity.Netcode
                     m_Hooks[hookIdx].OnAfterSendMessage(clientId, ref message, delivery, tmpSerializer.Length + headerSerializer.Length);
                 }
             }
-
+            #region OOI_CC
+            if (ReportMessage)
+            {
+                OnMessageSent.Invoke(StackTraceUtility.ExtractStackTrace(),
+                    tmpSerializer.Length + headerSerializer.Length, clientIds.Count);
+            }
+            #endregion
             return tmpSerializer.Length + headerSerializer.Length;
         }
+
+        #region OOI_CC
+        internal Action<string, int, int> OnMessageSent = (value1, value2, value3) => { };
+        internal bool ReportMessage;
+        #endregion
 
         internal unsafe int SendPreSerializedMessage<TMessageType>(in FastBufferWriter tmpSerializer, int maxSize, ref TMessageType message, NetworkDelivery delivery, ulong clientId)
             where TMessageType : INetworkMessage


### PR DESCRIPTION
- Added: custom functionality of reporting the network messages stats, like length and stacktrace, and triggering this functionality on and off using custom event subscribing.

## Changelog

- Added: custom functionality of reporting the network messages stats, like length and stacktrace, and triggering this functionality on and off using custom event subscribing.

## Testing and Documentation

- No tests have been added.
- Includes unit tests.
- Includes integration tests.
- No documentation changes or additions were necessary.
- Includes documentation for previously-undocumented public API entry points.
- Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
